### PR TITLE
Add @stylexjs/stylex to dependencies

### DIFF
--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -7,5 +7,8 @@
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
+  },
+  "dependencies": {
+    "@stylexjs/stylex": "0.7.5"
   }
 }


### PR DESCRIPTION
Hi @BMCwebdev,

I got this error when trying to run the demo app, this fix should fix it:


```bash
Import trace for requested module:
./src/app/page.js
 GET / 500 in 82ms
 ⨯ ../stylexAcmeNextTest/packages/tokens/coreTokens.stylex.js:1:1
Module not found: Can't resolve '@stylexjs/stylex'
> 1 | import { defineVars } from "@stylexjs/stylex";
```

P.S.,
Actually, I don't get this error when using the SWC plugin